### PR TITLE
fix: dispose Mapillary viewer on unmount to prevent memory leak

### DIFF
--- a/client/src/components/StreetViewComponent.vue
+++ b/client/src/components/StreetViewComponent.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref, watch } from 'vue'
+import { onMounted, onUnmounted, ref, watch } from 'vue'
 import { Viewer } from 'mapillary-js'
 import { CANDIDATE_LOCATIONS } from '@/consts'
 import type { LatLng } from '@/types'
@@ -166,6 +166,13 @@ const initViewer = () => {
 
 onMounted(() => {
   initViewer()
+})
+
+onUnmounted(() => {
+  if (viewer.value) {
+    viewer.value.remove()
+    viewer.value = null
+  }
 })
 
 defineExpose({


### PR DESCRIPTION
## Summary
  - Adds `onUnmounted` lifecycle hook to clean up Mapillary viewer instance
  - Prevents memory leaks by calling `viewer.remove()` when component unmounts

This PR is to eliminate a memory leak that causes a WindowServer crash on Intel Macs