### PR TITLE
fix: Github typo

### DIFF
--- a/client/src/components/FooterComponent.vue
+++ b/client/src/components/FooterComponent.vue
@@ -35,7 +35,7 @@
             class="text-muted-foreground cursor-pointer font-[Roboto] text-base"
             @click="openGithub"
           >
-            Github
+            GitHub
           </Button>
           <Button
             v-if="isCurrentUserLoaded && !currentUser"

--- a/client/src/components/HeaderComponent.vue
+++ b/client/src/components/HeaderComponent.vue
@@ -37,7 +37,7 @@
         class="text-muted-foreground cursor-pointer rounded-none font-[JetBrains_Mono] text-lg"
         @click="openGithub"
       >
-        [Github]
+        [GitHub]
       </Button>
       <Button
         v-if="isCurrentUserLoaded && !currentUser"


### PR DESCRIPTION
Rename Github to GitHub, using big letter H

Btw, one question. I am just courious how you managed, to save the valid image ID-s to the DB? You have a script for it to mine, or any other solution? :D

Thanks!